### PR TITLE
Add Render deploy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,11 @@ git push <heroku|staging|production> master
 
 * Create user manually (these are automatically verified, no need for email confirmation)
 
-	-  `heroku run python manage.py create_user --app app_name`
+        -  `heroku run python manage.py create_user --app app_name`
+
+
+# Render
+
+This repo includes a `render.yaml` file for deploying on [Render](https://render.com).
+Create a new **Web Service** from this repository and Render will automatically use the build and start commands defined in that file.
+Remember to configure the required environment variables based on `.env.example`.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: financial-dashboard
+    env: python
+    buildCommand: |
+      pip install -r requirements.txt
+      npm install
+      npm run build
+    startCommand: gunicorn -w 2 wsgi:application


### PR DESCRIPTION
## Summary
- include a `render.yaml` definition for easy deployment
- document Render usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------